### PR TITLE
Set monospace font for training results

### DIFF
--- a/app/src/main/java/es/eoinrul/ecwt/TrainingResultsActivity.kt
+++ b/app/src/main/java/es/eoinrul/ecwt/TrainingResultsActivity.kt
@@ -79,7 +79,7 @@ class TrainingResultsActivity : AppCompatActivity() {
     }
 
     private fun formatColorId(c : Int) : String {
-        return "<font color=\"#" + Integer.toHexString(getColor(c)).substring(2) + "\">"
+        return "<font face=monospace color=\"#" + Integer.toHexString(getColor(c)).substring(2) + "\">"
     }
 
     private fun formatEditDetails(edits : List<SingleEdit>) : String {


### PR DESCRIPTION
By giving each letter the same width, each error is as wide as the others, better representing your results.