### PR TITLE
Make the app run on Android 5 (API 22)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "es.eoinrul.ecwt"
-        minSdkVersion 23
+        minSdkVersion 22
         targetSdkVersion 30
         versionCode 44
         versionName "4.4"

--- a/app/src/main/java/es/eoinrul/ecwt/TrainingResultsActivity.kt
+++ b/app/src/main/java/es/eoinrul/ecwt/TrainingResultsActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
 
@@ -79,7 +80,7 @@ class TrainingResultsActivity : AppCompatActivity() {
     }
 
     private fun formatColorId(c : Int) : String {
-        return "<font face=monospace color=\"#" + Integer.toHexString(getColor(c)).substring(2) + "\">"
+        return "<font face=monospace color=\"#" + Integer.toHexString(ContextCompat.getColor(this, c)).substring(2) + "\">"
     }
 
     private fun formatEditDetails(edits : List<SingleEdit>) : String {


### PR DESCRIPTION
This requires a deprecated `AudioTrack` constructor, but devices with API 23 or above should not see any changes. The `minSdkVersion` could probably go to 21, but I can't test it.